### PR TITLE
Add Support For Gemini TTS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  node:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 20
+          - 22
+          - 24
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -146,6 +146,39 @@ The most notable of these is [`thinking_config`](https://ai.google.dev/gemini-ap
 
 For more details, refer to the [Gemini API docs](https://ai.google.dev/gemini-api/docs/openai#extra-body).
 
+
+## Text-to-Speech (TTS)
+
+The `/v1/audio/speech` endpoint provides OpenAI-compatible text-to-speech functionality powered by Gemini's TTS models.
+
+### Example Usage
+
+```bash
+curl https://your-endpoint.com/v1/audio/speech \
+  -H "Authorization: Bearer YOUR_GEMINI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "tts-1",
+    "input": "Hello! This is a test of the text-to-speech API.",
+    "voice": "alloy",
+    "response_format": "mp3"
+  }' \
+  --output speech.mp3
+```
+
+### Model Mapping
+- `tts-1` → `gemini-2.5-flash-preview-tts` (faster, optimized for speed)
+- `tts-1-hd` → `gemini-2.5-pro-preview-tts` (higher quality)
+
+### Voice Mapping
+OpenAI voices are mapped to Gemini TTS voices:
+- `alloy` → Puck (neutral, balanced)
+- `echo` → Charon (male voice)
+- `fable` → Kore (expressive)
+- `onyx` → Fenrir (deep, authoritative)
+- `nova` → Aoede (warm, friendly)
+- `shimmer` → Aoede (similar to nova)
+
 ---
 
 ## Supported API endpoints and applicable parameters

--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ curl https://your-endpoint.com/v1/audio/speech \
     "model": "tts-1",
     "input": "Hello! This is a test of the text-to-speech API.",
     "voice": "alloy",
-    "response_format": "mp3"
+    "response_format": "wav"
   }' \
-  --output speech.mp3
+  --output speech.wav
 ```
 
 ### Model Mapping
@@ -239,8 +239,9 @@ OpenAI voices are mapped to Gemini TTS voices:
       - Supported: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`
       - Maps to Gemini voices: Puck, Charon, Kore, Fenrir, Aoede
   - [x] `response_format`
-      - Supported: `mp3`, `opus`, `aac`, `flac`, `wav`, `pcm`
-      - Default: `mp3`
+      - Supported: `wav`, `pcm`
+      - Default: `wav`
+      - Note: Gemini returns raw PCM audio (24 kHz, 16-bit, mono). Only WAV (with proper headers) and raw PCM formats are supported. For mp3, opus, aac, or flac, use external conversion tools like ffmpeg.
   - [ ] `speed` (not yet implemented)
 
   </details>

--- a/README.md
+++ b/README.md
@@ -194,3 +194,20 @@ For more details, refer to the [Gemini API docs](https://ai.google.dev/gemini-ap
 - [x] `embeddings`
   - [x] `dimensions`
 - [x] `models`
+- [x] `audio/speech` (Text-to-Speech)
+  <details>
+
+  - [x] `model`
+      - `tts-1` => `gemini-2.5-flash-preview-tts`
+      - `tts-1-hd` => `gemini-2.5-pro-preview-tts`
+      - Can also specify Gemini model names directly
+  - [x] `input` (required)
+  - [x] `voice` (required)
+      - Supported: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`
+      - Maps to Gemini voices: Puck, Charon, Kore, Fenrir, Aoede
+  - [x] `response_format`
+      - Supported: `mp3`, `opus`, `aac`, `flac`, `wav`, `pcm`
+      - Default: `mp3`
+  - [ ] `speed` (not yet implemented)
+
+  </details>

--- a/README.md
+++ b/README.md
@@ -231,17 +231,17 @@ OpenAI voices are mapped to Gemini TTS voices:
   <details>
 
   - [x] `model`
-      - `tts-1` => `gemini-2.5-flash-preview-tts`
-      - `tts-1-hd` => `gemini-2.5-pro-preview-tts`
-      - Can also specify Gemini model names directly
+    - `tts-1` => `gemini-2.5-flash-preview-tts`
+    - `tts-1-hd` => `gemini-2.5-pro-preview-tts`
+    - Can also specify Gemini model names directly
   - [x] `input` (required)
   - [x] `voice` (required)
-      - Supported: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`
-      - Maps to Gemini voices: Puck, Charon, Kore, Fenrir, Aoede
+    - Supported: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`
+    - Maps to Gemini voices: Puck, Charon, Kore, Fenrir, Aoede
   - [x] `response_format`
-      - Supported: `wav`, `pcm`
-      - Default: `wav`
-      - Note: Gemini returns raw PCM audio (24 kHz, 16-bit, mono). Only WAV (with proper headers) and raw PCM formats are supported. For mp3, opus, aac, or flac, use external conversion tools like ffmpeg.
+    - Supported: `wav`, `pcm`
+    - Default: `wav`
+    - Note: Gemini returns raw PCM audio (24 kHz, 16-bit, mono). Only WAV (with proper headers) and raw PCM formats are supported. For mp3, opus, aac, or flac, use external conversion tools like ffmpeg.
   - [ ] `speed` (not yet implemented)
 
   </details>

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ or "models/". Otherwise, these defaults apply:
 ## Built-in tools
 
 To use the **web search** tool, append ":search" to the model name
-(e.g., "gemini-2.5-flash:search").
+(e.g. "gemini-2.5-flash:search").
 
 Note: The `annotations` message property is not implemented.
 
@@ -149,13 +149,14 @@ For more details, refer to the [Gemini API docs](https://ai.google.dev/gemini-ap
 
 ## Text-to-Speech (TTS)
 
-The `/v1/audio/speech` endpoint provides OpenAI-compatible text-to-speech functionality powered by Gemini's TTS models.
+The `/v1/audio/speech` endpoint exposes an OpenAI-style subset backed by Gemini TTS.
+It is intentionally documented as a subset because the endpoint currently returns only WAV or raw PCM audio and does not implement every OpenAI speech parameter.
 
-### Example Usage
+### Example usage
 
 ```bash
 curl https://your-endpoint.com/v1/audio/speech \
-  -H "Authorization: Bearer YOUR_GEMINI_API_KEY" \
+  -H "Authorization: Bearer $GEMINI_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "model": "tts-1",
@@ -166,18 +167,31 @@ curl https://your-endpoint.com/v1/audio/speech \
   --output speech.wav
 ```
 
-### Model Mapping
-- `tts-1` → `gemini-2.5-flash-preview-tts` (faster, optimized for speed)
-- `tts-1-hd` → `gemini-2.5-pro-preview-tts` (higher quality)
+### Model mapping
 
-### Voice Mapping
-OpenAI voices are mapped to Gemini TTS voices:
-- `alloy` → Puck (neutral, balanced)
-- `echo` → Charon (male voice)
-- `fable` → Kore (expressive)
-- `onyx` → Fenrir (deep, authoritative)
-- `nova` → Aoede (warm, friendly)
-- `shimmer` → Aoede (similar to nova)
+- `tts-1` → `gemini-2.5-flash-preview-tts`
+- `tts-1-hd` → `gemini-2.5-pro-preview-tts`
+- Gemini model names can be passed directly, with or without the `models/` prefix (for example, `gemini-3.1-flash-tts-preview`).
+
+### Voice mapping
+
+OpenAI voice names are mapped to Gemini prebuilt voices:
+
+- `alloy` → Puck (upbeat)
+- `echo` → Charon (informative)
+- `fable` → Kore (firm)
+- `onyx` → Fenrir (excitable)
+- `nova` → Aoede (breezy)
+- `shimmer` → Aoede (breezy)
+
+### Compatibility notes
+
+- `input` and `voice` are required.
+- `response_format` supports `wav` and `pcm`; the default is `wav`.
+- Gemini returns 24 kHz, 16-bit, mono PCM. WAV responses add a standard RIFF/WAVE header around that PCM payload.
+- `mp3`, `opus`, `aac`, and `flac` are rejected. Convert WAV/PCM externally when one of those formats is required.
+- `speed`, `instructions`, and `stream_format` are not implemented. Omit them when using this endpoint.
+- The response is buffered rather than streamed.
 
 ---
 
@@ -227,21 +241,22 @@ OpenAI voices are mapped to Gemini TTS voices:
 - [x] `embeddings`
   - [x] `dimensions`
 - [x] `models`
-- [x] `audio/speech` (Text-to-Speech)
+- [x] `audio/speech` (Text-to-Speech subset)
   <details>
 
   - [x] `model`
     - `tts-1` => `gemini-2.5-flash-preview-tts`
     - `tts-1-hd` => `gemini-2.5-pro-preview-tts`
-    - Can also specify Gemini model names directly
+    - Gemini TTS model names can also be specified directly.
   - [x] `input` (required)
   - [x] `voice` (required)
-    - Supported: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`
-    - Maps to Gemini voices: Puck, Charon, Kore, Fenrir, Aoede
+    - Supported aliases: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`
+    - Mapped Gemini voices: Puck, Charon, Kore, Fenrir, Aoede
   - [x] `response_format`
     - Supported: `wav`, `pcm`
     - Default: `wav`
-    - Note: Gemini returns raw PCM audio (24 kHz, 16-bit, mono). Only WAV (with proper headers) and raw PCM formats are supported. For mp3, opus, aac, or flac, use external conversion tools like ffmpeg.
-  - [ ] `speed` (not yet implemented)
+  - [ ] `speed`
+  - [ ] `instructions`
+  - [ ] `stream_format`
 
   </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "@whatwg-node/server": "0.9"
       },
       "devDependencies": {
-        "nodemon": "^3.1.7"
+        "nodemon": "3"
       }
     },
     "node_modules/@kamilkisiela/fast-url-parser": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "start": "node node.mjs",
     "dev": "nodemon --watch node.mjs --watch src/*.mjs node.mjs",
+    "test": "node --test",
     "start:deno": "deno --allow-env --allow-net deno.mjs",
     "dev:deno": "deno --watch --allow-env --allow-net deno.mjs",
     "start:bun": "bun bun.mjs",

--- a/test/speech.test.mjs
+++ b/test/speech.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import test from "node:test";
+
+import worker from "../src/worker.mjs";
+
+const ENDPOINT = "https://proxy.example/v1/audio/speech";
+const PCM = Buffer.from([0x00, 0x00, 0xff, 0x7f, 0x00, 0x80]);
+
+function geminiAudioResponse (pcm = PCM) {
+  return new Response(JSON.stringify({
+    candidates: [{
+      content: {
+        parts: [{
+          inlineData: {
+            mimeType: "audio/L16;codec=pcm;rate=24000",
+            data: pcm.toString("base64"),
+          },
+        }],
+      },
+    }],
+  }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function speechRequest (body, method = "POST") {
+  return new Request(ENDPOINT, {
+    method,
+    headers: {
+      Authorization: "Bearer test-gemini-key",
+      "Content-Type": "application/json",
+    },
+    ...(method === "POST" && { body: JSON.stringify(body) }),
+  });
+}
+
+async function withMockFetch (mock, callback) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = mock;
+  try {
+    return await callback();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+test("audio/speech maps aliases and wraps Gemini PCM as WAV", async () => {
+  let upstream;
+
+  await withMockFetch(async (url, init) => {
+    upstream = { url: String(url), init };
+    return geminiAudioResponse();
+  }, async () => {
+    const response = await worker.fetch(speechRequest({
+      model: "tts-1",
+      input: "Hello from the test suite.",
+      voice: "alloy",
+      response_format: "wav",
+    }));
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "audio/wav");
+    assert.equal(response.headers.get("access-control-allow-origin"), "*");
+
+    const wav = Buffer.from(await response.arrayBuffer());
+    assert.equal(wav.subarray(0, 4).toString("ascii"), "RIFF");
+    assert.equal(wav.subarray(8, 12).toString("ascii"), "WAVE");
+    assert.equal(wav.readUInt32LE(24), 24000);
+    assert.equal(wav.readUInt16LE(22), 1);
+    assert.equal(wav.readUInt16LE(34), 16);
+    assert.equal(wav.readUInt32LE(40), PCM.length);
+    assert.deepEqual(wav.subarray(44), PCM);
+  });
+
+  assert.equal(
+    upstream.url,
+    "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent",
+  );
+  assert.equal(upstream.init.headers["x-goog-api-key"], "test-gemini-key");
+
+  const payload = JSON.parse(upstream.init.body);
+  assert.deepEqual(payload.contents, [{ parts: [{ text: "Hello from the test suite." }] }]);
+  assert.equal(
+    payload.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName,
+    "Puck",
+  );
+});
+
+test("audio/speech returns unmodified PCM when requested", async () => {
+  await withMockFetch(async () => geminiAudioResponse(), async () => {
+    const response = await worker.fetch(speechRequest({
+      model: "tts-1-hd",
+      input: "PCM output",
+      voice: "echo",
+      response_format: "pcm",
+    }));
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "audio/pcm");
+    assert.deepEqual(Buffer.from(await response.arrayBuffer()), PCM);
+  });
+});
+
+test("audio/speech accepts direct Gemini model names with models/ prefix", async () => {
+  let upstreamUrl;
+
+  await withMockFetch(async (url) => {
+    upstreamUrl = String(url);
+    return geminiAudioResponse();
+  }, async () => {
+    const response = await worker.fetch(speechRequest({
+      model: "models/gemini-3.1-flash-tts-preview",
+      input: "Direct model",
+      voice: "nova",
+      response_format: "pcm",
+    }));
+
+    assert.equal(response.status, 200);
+  });
+
+  assert.equal(
+    upstreamUrl,
+    "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent",
+  );
+});
+
+test("audio/speech rejects missing input before calling Gemini", async () => {
+  let calls = 0;
+
+  await withMockFetch(async () => {
+    calls += 1;
+    return geminiAudioResponse();
+  }, async () => {
+    const response = await worker.fetch(speechRequest({
+      model: "tts-1",
+      voice: "alloy",
+      response_format: "wav",
+    }));
+
+    assert.equal(response.status, 400);
+    assert.equal(await response.text(), "input is required");
+    assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  });
+
+  assert.equal(calls, 0);
+});
+
+test("audio/speech rejects missing voice before calling Gemini", async () => {
+  let calls = 0;
+
+  await withMockFetch(async () => {
+    calls += 1;
+    return geminiAudioResponse();
+  }, async () => {
+    const response = await worker.fetch(speechRequest({
+      model: "tts-1",
+      input: "Missing voice",
+      response_format: "wav",
+    }));
+
+    assert.equal(response.status, 400);
+    assert.equal(await response.text(), "voice is required");
+  });
+
+  assert.equal(calls, 0);
+});
+
+test("audio/speech rejects unsupported output formats", async () => {
+  await withMockFetch(async () => geminiAudioResponse(), async () => {
+    const response = await worker.fetch(speechRequest({
+      model: "tts-1",
+      input: "Unsupported format",
+      voice: "alloy",
+      response_format: "mp3",
+    }));
+
+    assert.equal(response.status, 400);
+    assert.match(await response.text(), /Only "wav" and "pcm" formats are supported/);
+  });
+});
+
+test("audio/speech preserves Gemini error status and CORS headers", async () => {
+  await withMockFetch(async () => new Response("quota exceeded", {
+    status: 429,
+    statusText: "Too Many Requests",
+  }), async () => {
+    const response = await worker.fetch(speechRequest({
+      model: "tts-1",
+      input: "Upstream error",
+      voice: "alloy",
+      response_format: "wav",
+    }));
+
+    assert.equal(response.status, 429);
+    assert.equal(await response.text(), "quota exceeded");
+    assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  });
+});
+
+test("audio/speech rejects non-POST requests", async () => {
+  const response = await worker.fetch(speechRequest({}, "GET"));
+
+  assert.equal(response.status, 400);
+  assert.equal(
+    await response.text(),
+    "The specified HTTP method is not allowed for the requested resource",
+  );
+});


### PR DESCRIPTION
Speech endpoints for Gemini TTS Flash and pro integrated into the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **audio speech (Text-to-Speech)** endpoint to generate audio from text with supported voice and model aliases.
  * Added **response_format** support for **`wav`** and **`pcm`**, with proper content types and CORS headers.
  * Improved request handling with validation (missing `input`/`voice`) and clearer errors for non-POST requests and unsupported formats.
* **Documentation**
  * Expanded TTS docs for `/v1/audio/speech`, including model/voice mapping and supported parameters/format behavior.
* **Tests**
  * Added a dedicated speech test suite and a CI workflow running tests across Node 20/22/24.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->